### PR TITLE
Mips npc

### DIFF
--- a/am/arch/mips32-npc/img/boot/start.S
+++ b/am/arch/mips32-npc/img/boot/start.S
@@ -4,7 +4,7 @@
 .type _qemu, @function
 
 _start:
-  li $sp, 0xf3fffffc
+  li $sp, 0xf7fffffc
   jal main
 
 _qemu:

--- a/am/arch/mips32-npc/img/boot/start.S
+++ b/am/arch/mips32-npc/img/boot/start.S
@@ -4,7 +4,7 @@
 .type _qemu, @function
 
 _start:
-  li $sp, 0x0001fffc
+  li $sp, 0xf3fffffc
   jal main
 
 _qemu:

--- a/am/arch/mips32-npc/img/loader.ld
+++ b/am/arch/mips32-npc/img/loader.ld
@@ -19,13 +19,13 @@ SECTIONS
     .data1 : { *(.data1) }
     . = 0xf0000000;
     __bss_start = .;
-    .sbss : { *(.sbss) *(.scommon) }
     .bss :
     {
 	*(.dynbss)
 	*(.bss)
 	*(COMMON)
     }
+    .sbss : { *(.sbss) *(.scommon) }
     __bss_end = . ;
     . = 0xf2000000;
     _heap_start = . ;

--- a/am/arch/mips32-npc/img/loader.ld
+++ b/am/arch/mips32-npc/img/loader.ld
@@ -3,5 +3,5 @@ SECTIONS
     . = 0x00000000;
     .text : { *(.text) }
     .data : { *(.data) }
-    .bss  : { *(.bss) }
+    .bss 0xf0000004 : { *(.bss) }
 }

--- a/am/arch/mips32-npc/img/loader.ld
+++ b/am/arch/mips32-npc/img/loader.ld
@@ -12,7 +12,7 @@ SECTIONS
 	*(.gnu.warning)
     } =0
     _etext = .;
-    PROVIDE (etexxt = .);
+    PROVIDE (etext = .);
     .fini : { *(.fini) } =0
     .data : {
 	_fdata = . ;

--- a/am/arch/mips32-npc/img/loader.ld
+++ b/am/arch/mips32-npc/img/loader.ld
@@ -1,32 +1,11 @@
 SECTIONS
 {
     . = 0x00000000;
-    .text : {
-        _ftext = . ;
-        *(.text)
-	*(.rodata)
-	*(.rodata1)
-	*(.reginfo)
-	*(.init)
-	*(.stub)
-	*(.gnu.warning)
-    } =0
-    .fini : { *(.fini) } =0
-    .data : {
-	_fdata = . ;
-	*(.data)
-    }
-    .data1 : { *(.data1) }
+    .text : { *(.text) } =0
+    .data : { *(.data) }
     . = 0xf0000000;
     __bss_start = .;
-    .bss :
-    {
-	*(.dynbss)
-	*(.bss)
-	*(COMMON)
-    }
-    .sbss : { *(.sbss) *(.scommon) }
+    .bss : { *(.bss) }
     __bss_end = . ;
-    . = 0xf2000000;
-    _heap_start = . ;
+    _heap_start = 0xf2000000;
 }

--- a/am/arch/mips32-npc/img/loader.ld
+++ b/am/arch/mips32-npc/img/loader.ld
@@ -5,14 +5,12 @@ SECTIONS
         _ftext = . ;
         *(.text)
 	*(.rodata)
-	*(.rodate1)
+	*(.rodata1)
 	*(.reginfo)
 	*(.init)
 	*(.stub)
 	*(.gnu.warning)
     } =0
-    _etext = .;
-    PROVIDE (etext = .);
     .fini : { *(.fini) } =0
     .data : {
 	_fdata = . ;
@@ -21,7 +19,6 @@ SECTIONS
     .data1 : { *(.data1) }
     . = 0xf0000000;
     __bss_start = .;
-    _fbss = . ;
     .sbss : { *(.sbss) *(.scommon) }
     .bss :
     {
@@ -29,9 +26,7 @@ SECTIONS
 	*(.bss)
 	*(COMMON)
     }
-    . = ALIGN(16);
-    __bss_end = 0xf2000000;
-    . = 0xf2000004;
-    _heap_start = .;
-    _heap_end = 0xf6000000;
+    __bss_end = . ;
+    . = 0xf2000000;
+    _heap_start = . ;
 }

--- a/am/arch/mips32-npc/img/loader.ld
+++ b/am/arch/mips32-npc/img/loader.ld
@@ -4,8 +4,7 @@ SECTIONS
     .text : { *(.text) } =0
     .data : { *(.data) }
     . = 0xf0000000;
-    __bss_start = .;
+    __bss_start = . ;
     .bss : { *(.bss) }
-    __bss_end = . ;
-    _heap_start = 0xf2000000;
+    _end = . ;
 }

--- a/am/arch/mips32-npc/img/loader.ld
+++ b/am/arch/mips32-npc/img/loader.ld
@@ -1,7 +1,37 @@
 SECTIONS
 {
     . = 0x00000000;
-    .text : { *(.text) }
-    .data : { *(.data) }
-    .bss 0xf0000004 : { *(.bss) }
+    .text : {
+        _ftext = . ;
+        *(.text)
+	*(.rodata)
+	*(.rodate1)
+	*(.reginfo)
+	*(.init)
+	*(.stub)
+	*(.gnu.warning)
+    } =0
+    _etext = .;
+    PROVIDE (etexxt = .);
+    .fini : { *(.fini) } =0
+    .data : {
+	_fdata = . ;
+	*(.data)
+    }
+    .data1 : { *(.data1) }
+    . = 0xf0000000;
+    __bss_start = .;
+    _fbss = . ;
+    .sbss : { *(.sbss) *(.scommon) }
+    .bss :
+    {
+	*(.dynbss)
+	*(.bss)
+	*(COMMON)
+    }
+    . = ALIGN(16);
+    __bss_end = 0xf2000000;
+    . = 0xf2000004;
+    _heap_start = .;
+    _heap_end = 0xf6000000;
 }

--- a/am/arch/mips32-npc/include/npc.h
+++ b/am/arch/mips32-npc/include/npc.h
@@ -2,11 +2,14 @@
 #define __NPC_H__
 
 #define VMEM_ADDR ((void *)0xc0000000)
-#define SCR_WIDTH 400
-#define SCR_HEIGHT 400
+#define SCR_WIDTH 200
+#define SCR_HEIGHT 200
 #define SCR_SIZE (SCR_WIDTH * SCR_HEIGHT)
-#define KEY_CODE_ADDR ((volatile unsigned int *)0xe0000000)
-#define KEY_CODE (*KEY_CODE_ADDR)
+#define Rx 0x0
+#define Tx 0x04
+#define STAT 0x08
+#define CTRL 0x0c
+#define SERIAL_PORT ((char *)0xe0000000)
 
 static inline u8 R(_Pixel p) { return p >> 16; }
 static inline u8 G(_Pixel p) { return p >> 8; }

--- a/am/arch/mips32-npc/include/npc.h
+++ b/am/arch/mips32-npc/include/npc.h
@@ -7,8 +7,8 @@
 #define SCR_SIZE (SCR_WIDTH * SCR_HEIGHT)
 #define KEY_CODE_ADDR ((volatile unsigned int *)0xe0000000)
 #define KEY_CODE (*KEY_CODE_ADDR)
-#define HEAP_START ((void *)0xf4000000)
-#define HEAP_END ((void *)0xf8000000)
+#define HEAP_START ((void *)0xf2000000)
+#define HEAP_END ((void *)0xf6000000)
 
 static inline u8 R(_Pixel p) { return p >> 16; }
 static inline u8 G(_Pixel p) { return p >> 8; }

--- a/am/arch/mips32-npc/include/npc.h
+++ b/am/arch/mips32-npc/include/npc.h
@@ -2,12 +2,12 @@
 #define __NPC_H__
 
 #define VMEM_ADDR ((void *)0xc0000000)
-#define SCR_WIDTH 320
-#define SCR_HEIGHT 200
+#define SCR_WIDTH 400
+#define SCR_HEIGHT 400
 #define SCR_SIZE (SCR_WIDTH * SCR_HEIGHT)
 #define KEY_CODE_ADDR ((volatile unsigned int *)0xe0000000)
 #define KEY_CODE (*KEY_CODE_ADDR)
-#define HEAP_START ((void *)0xf0000000)
+#define HEAP_START ((void *)0xf4000000)
 #define HEAP_END ((void *)0xf8000000)
 
 static inline u8 R(_Pixel p) { return p >> 16; }

--- a/am/arch/mips32-npc/include/npc.h
+++ b/am/arch/mips32-npc/include/npc.h
@@ -7,8 +7,6 @@
 #define SCR_SIZE (SCR_WIDTH * SCR_HEIGHT)
 #define KEY_CODE_ADDR ((volatile unsigned int *)0xe0000000)
 #define KEY_CODE (*KEY_CODE_ADDR)
-#define HEAP_START ((void *)0xf2000000)
-#define HEAP_END ((void *)0xf6000000)
 
 static inline u8 R(_Pixel p) { return p >> 16; }
 static inline u8 G(_Pixel p) { return p >> 8; }

--- a/am/arch/mips32-npc/src/asym.c
+++ b/am/arch/mips32-npc/src/asym.c
@@ -5,6 +5,7 @@
 #define INTERVAL 10000
 #define INTERVAL_MIN 1000  //min interval(cpu use 1000 cycles to deal interrupt)
 #define COUNT_MAX 0xffffffff	//count reg max value
+#define NOTIME
 
 ulong npc_cycles = 0;
 ulong npc_time = 1;
@@ -20,7 +21,11 @@ void SetCompare(u32 compare){
 }
 
 ulong _uptime() {
+#ifdef NOTIME
+  return npc_time++;
+#else
   return npc_time;
+#endif
 }
 
 void _time_event(){
@@ -32,6 +37,9 @@ ulong _cycles(){
 }
 
 void _asye_init(){
+#ifdef NOTIME
+  return;
+#else
   u32 count= GetCount();
   if(count + INTERVAL > COUNT_MAX){
     SetCompare(count + INTERVAL - COUNT_MAX);
@@ -39,6 +47,7 @@ void _asye_init(){
   else{//count overflow
     SetCompare(count + INTERVAL);
   }
+#endif
 }
 
 void _listen(_RegSet* (*l)(int ex, _RegSet *regs)){

--- a/am/arch/mips32-npc/src/asym.c
+++ b/am/arch/mips32-npc/src/asym.c
@@ -1,7 +1,8 @@
 #include <am.h>
 #include <npc.h>
 #include <arch.h>
-#define INTERVAL 20000
+#define HZ 10
+#define INTERVAL 10000
 #define INTERVAL_MIN 1000  //min interval(cpu use 1000 cycles to deal interrupt)
 #define COUNT_MAX 0xffffffff	//count reg max value
 

--- a/am/arch/mips32-npc/src/ioe.c
+++ b/am/arch/mips32-npc/src/ioe.c
@@ -5,6 +5,9 @@ int curr_line = 0;
 int curr_col = 0;
 extern char font8x8_basic[128][8];
 u8 *fb;
+extern char get_stat();
+static char *csend = SERIAL_PORT + Tx;
+static char *crecv = SERIAL_PORT + Rx;
 
 void draw_character(char ch, int x, int y, _Pixel p) {
   int i, j;
@@ -32,9 +35,20 @@ void vga_init(){
   fb = VMEM_ADDR;
 }
 
+void out_byte(char ch) {
+  while((get_stat() >> 3) & 0x1);
+  *csend = ch;
+}
+
+char in_byte(){
+  if(!(get_stat() & 0x1)) return '\0';
+  else return *crecv;
+}
+
 void _putc(char ch) {
   //TODO:use uart
-  if(ch == '\n'){
+  out_byte(ch);
+  /*if(ch == '\n'){
     curr_col = 0;
     curr_line += 8;
   }
@@ -48,7 +62,7 @@ void _putc(char ch) {
   }
   if(curr_line >= SCR_HEIGHT){
     curr_line = 0;
-  }
+}*/
 }
 
 void _draw_f(_Pixel *p) {
@@ -66,6 +80,31 @@ void _draw_sync() {
   //not to do
 }
 
+static inline int keydown(int e) { return (e & 0x8000) != 0; }
+static inline int upevent(int e) { return e; }
+static inline int downevent(int e) { return e | 0x8000; }
+
 int _peek_key(){
+  /*int key_code = in_byte();
+  switch(key_code){
+    case 'j': return downevent(_KEY_Z);break;
+    case 'k': return downevent(_KEY_X);break;
+    case 'w': return downevent(_KEY_UP);break;
+    case 's': return downevent(_KEY_DOWN);break;
+    case 'a': return downevent(_KEY_LEFT);break;
+    case 'd': return downevent(_KEY_RIGHT);break;
+    case 0xf0:{
+        switch(in_byte()){
+    	  case 'j': return upevent(_KEY_Z);break;
+    	  case 'k': return upevent(_KEY_X);break;
+    	  case 'w': return upevent(_KEY_UP);break;
+    	  case 's': return upevent(_KEY_DOWN);break;
+    	  case 'a': return upevent(_KEY_LEFT);break;
+    	  case 'd': return upevent(_KEY_RIGHT);break;
+          default: return upevent(_KEY_NONE);
+        }
+    }
+    default: return upevent(_KEY_NONE);
+  }*/
   return 0;
 }

--- a/am/arch/mips32-npc/src/trm.c
+++ b/am/arch/mips32-npc/src/trm.c
@@ -4,6 +4,11 @@
 _Area _heap;
 _Screen _screen;
 
+extern void *_heap_start;
+extern void *_heap_end;
+extern char *__bss_start;
+extern char *__bss_end;
+
 void _trm_init() {
   serial_init();
   memory_init();
@@ -25,11 +30,12 @@ void _halt(int code) {
 
 void memory_init(){
   //probe a memory for heap
-  _heap.start = HEAP_START;
-  _heap.end = HEAP_END;
-  /*unsigned int i;
-  char *bss = ((void *)0xf0000004);
-  for(i = 0; i < 0x1fffffc; i++) { bss[i] = 0; }*/
+  _heap.start = _heap_start;
+  _heap.end = _heap_end;
+  char *st = __bss_start;
+  char *ed = __bss_end;
+  for(;st != ed; st++)
+    *st = 0;
 }
 
 void serial_init(){

--- a/am/arch/mips32-npc/src/trm.c
+++ b/am/arch/mips32-npc/src/trm.c
@@ -6,10 +6,6 @@
 _Area _heap;
 _Screen _screen;
 
-extern char _heap_start;
-extern char __bss_start;
-extern char __bss_end;
-
 void _trm_init() {
   serial_init();
   memory_init();
@@ -31,13 +27,17 @@ void _halt(int code) {
 
 void memory_init(){
   //probe a memory for heap
-  _heap.start = (void *)(&_heap_start);
-  _heap.end = (char *)(&_heap_start) + MAX_MEMORY_SIZE;
-  volatile char *st = (void *)(&__bss_start);
-  volatile char *ed = (void *)(&__bss_end);
-  for(; st != ed; st++) {
-    *st = 0 ;
-  }
+  extern char _end;
+  extern char __bss_start;
+  unsigned int st = (unsigned int)(&_end);
+  unsigned int ed = (unsigned int)(&_end) + MAX_MEMORY_SIZE;
+  _heap.start = (void *)(st);
+  _heap.end = (void *)(ed);
+  st = (unsigned int)(&__bss_start);
+  ed = (unsigned int)(&_end);
+  char *bss = (void *)(st);
+  unsigned int i;
+  for(i = st;i < ed; i++) { bss[i - st] = 0; }
 }
 
 void serial_init(){

--- a/am/arch/mips32-npc/src/trm.c
+++ b/am/arch/mips32-npc/src/trm.c
@@ -27,6 +27,9 @@ void memory_init(){
   //probe a memory for heap
   _heap.start = HEAP_START;
   _heap.end = HEAP_END;
+  /*unsigned int i;
+  char *bss = ((void *)0xf0000004);
+  for(i = 0; i < 0x1fffffc; i++) { bss[i] = 0; }*/
 }
 
 void serial_init(){

--- a/am/arch/mips32-npc/src/trm.c
+++ b/am/arch/mips32-npc/src/trm.c
@@ -6,9 +6,9 @@
 _Area _heap;
 _Screen _screen;
 
-extern unsigned int _heap_start;
-extern unsigned int __bss_start;
-extern unsigned int __bss_end;
+extern char _heap_start;
+extern char __bss_start;
+extern char __bss_end;
 
 void _trm_init() {
   serial_init();
@@ -31,16 +31,12 @@ void _halt(int code) {
 
 void memory_init(){
   //probe a memory for heap
-  volatile unsigned int st = _heap_start;
-  volatile unsigned int ed = _heap_start + MAX_MEMORY_SIZE;
-  _heap.start = (void *)st;
-  _heap.end = (void *)ed;
-  st = __bss_start;
-  ed = __bss_end;
-  volatile char *bss = (void *)st;
-  volatile unsigned int i;
-  for(i = st; i < ed; i++) {
-    bss[i - st] = 0 ;
+  _heap.start = (void *)(&_heap_start);
+  _heap.end = (char *)(&_heap_start) + MAX_MEMORY_SIZE;
+  volatile char *st = (void *)(&__bss_start);
+  volatile char *ed = (void *)(&__bss_end);
+  for(; st != ed; st++) {
+    *st = 0 ;
   }
 }
 

--- a/am/arch/mips32-npc/src/trm.c
+++ b/am/arch/mips32-npc/src/trm.c
@@ -6,6 +6,11 @@
 _Area _heap;
 _Screen _screen;
 
+char __attribute__((__noinline__)) get_stat(){
+  char *stat = SERIAL_PORT + STAT;
+  return *stat;
+}
+
 void _trm_init() {
   serial_init();
   memory_init();

--- a/am/arch/mips32-npc/src/trm.c
+++ b/am/arch/mips32-npc/src/trm.c
@@ -1,13 +1,14 @@
 #include <am.h>
 #include <npc.h>
 
+#define MAX_MEMORY_SIZE 0x4000000
+
 _Area _heap;
 _Screen _screen;
 
-extern void *_heap_start;
-extern void *_heap_end;
-extern char *__bss_start;
-extern char *__bss_end;
+extern unsigned int _heap_start;
+extern unsigned int __bss_start;
+extern unsigned int __bss_end;
 
 void _trm_init() {
   serial_init();
@@ -30,12 +31,17 @@ void _halt(int code) {
 
 void memory_init(){
   //probe a memory for heap
-  _heap.start = _heap_start;
-  _heap.end = _heap_end;
-  char *st = __bss_start;
-  char *ed = __bss_end;
-  for(;st != ed; st++)
-    *st = 0;
+  volatile unsigned int st = _heap_start;
+  volatile unsigned int ed = _heap_start + MAX_MEMORY_SIZE;
+  _heap.start = (void *)st;
+  _heap.end = (void *)ed;
+  st = __bss_start;
+  ed = __bss_end;
+  volatile char *bss = (void *)st;
+  volatile unsigned int i;
+  for(i = st; i < ed; i++) {
+    bss[i - st] = 0 ;
+  }
 }
 
 void serial_init(){

--- a/apps/litenes/src/fce.c
+++ b/apps/litenes/src/fce.c
@@ -154,6 +154,7 @@ void fce_update_screen()
 int main() {
   _trm_init();
   _ioe_init();
+  _asye_init();
 
   fce_load_rom(rom_mario_nes);
   fce_init();

--- a/apps/microbench/include/benchmark.h
+++ b/apps/microbench/include/benchmark.h
@@ -31,7 +31,7 @@ extern "C" {
   def(  md5,   "md5",  16 MB, 20200, true, 0xa2579514, "MD5 digest") \
 
 // Each benchmark will run REPEAT times
-#define REPEAT  3
+#define REPEAT  1
 
 #define DECL(_name, _sname, _mlim, _ref, _en, _cs, _desc) \
   void bench_##_name##_prepare(); \

--- a/apps/microbench/include/benchmark.h
+++ b/apps/microbench/include/benchmark.h
@@ -19,7 +19,6 @@ extern "C" {
 // the list of benchmarks
 //       Name        |  Mem  |Ref(us)| Enable | Checksum | Desc
 #define BENCHMARK_LIST(def) \
-  def(qsort, "qsort", 640 KB, 28620, true, 0x2e074bc8, "Quick sort") \
   def(queen, "queen",   0 KB,  5490, true, 0x00003778, "Queen placement") \
   def(   bf,    "bf",  32 KB, 17520, true, 0x432858fd, "Brainf**k interpreter") \
   def(  fib,   "fib", 256 KB, 28380, true, 0xebdc5f80, "Fibonacci number") \

--- a/apps/microbench/include/benchmark.h
+++ b/apps/microbench/include/benchmark.h
@@ -19,6 +19,7 @@ extern "C" {
 // the list of benchmarks
 //       Name        |  Mem  |Ref(us)| Enable | Checksum | Desc
 #define BENCHMARK_LIST(def) \
+  def(qsort, "qsort", 640 KB, 28620, true, 0x2e074bc8, "Quick sort") \
   def(queen, "queen",   0 KB,  5490, true, 0x00003778, "Queen placement") \
   def(   bf,    "bf",  32 KB, 17520, true, 0x432858fd, "Brainf**k interpreter") \
   def(  fib,   "fib", 256 KB, 28380, true, 0xebdc5f80, "Fibonacci number") \

--- a/apps/nemu/src/main.c
+++ b/apps/nemu/src/main.c
@@ -14,7 +14,7 @@ int main(int argc, char *argv[]) {
 	restart();
 
 	/* Receive commands from user. */
-	ui_mainloop();
+	//ui_mainloop();
 
 	return 0;
 }


### PR DESCRIPTION
修改了heap的方式，以bbs的末尾为heap的起始处
修改了bbs的加载地址，现在的bbs从ddr的开始处0xf0000000处加载，并进行了清零
可以初步运行litenes（可以进入演示画面）
修改了putc（进行串口输出，仍需测试）
#define NOTIME （at asye.c)可以避免使用时钟中断（用以调试litenes）